### PR TITLE
ci: update shared renovate config

### DIFF
--- a/renovate-default.json
+++ b/renovate-default.json
@@ -1,15 +1,28 @@
 {
-  "baseBranches": ["main"],
+  "baseBranches": [
+    "main"
+  ],
   "configMigration": true,
-  "extends": ["config:best-practices"],
-  "labels": ["dependencies"],
+  "extends": [
+    "config:best-practices"
+  ],
+  "labels": [
+    "dependencies"
+  ],
   "packageRules": [
     {
       "groupName": "{{manager}} non-major dependencies",
       "groupSlug": "{{manager}}-non-major",
-      "matchPackagePatterns": ["*"],
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
+      "automerge": true,
+      "matchPackageNames": [
+        "*"
+      ]
     }
   ],
   "rebaseWhen": "conflicted"


### PR DESCRIPTION
# Description

- the `configMigrate` option for renovate ensures that we stay up-to-date with any config option changes and deprecations that the renovatebot team make. However renovate will update config in the default locations (in this case `.github/renovate.json`) but not any other locations.

- this change brings the default shared config used by other repositories in sync with the latest changes applied by renovatebot

- the whitespace changes are based on renovatebots changes (even if I personally don't like them...)

# Checklist

* [x] I have run pre-commit linting and security checks where applicable.
* [x] Where applicable I have updated the README.
* [ ] I have Tested my changes.
