### PR TITLE
ci: add a new check for validating json

### DIFF
--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -1,0 +1,20 @@
+# This workflow setups an environment with python and uv to be able to run check-jsonschema
+
+name: validate-json
+
+on:
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+  validate-renovate-json:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install the latest version of uv and set the python version
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: 3.13
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Run check-jsonschema
+        run: uvx check-jsonschema --builtin-schema vendor.renovate renovate-default.json .github/renovate.json


### PR DESCRIPTION
- uses check-jsonschema to validate renovate config

I'm trying to add a new workflow that can be used as a check for the purposes of allowing renovate to automerge the PR's it creates (only when it is anything other than a major version change of something).
