### PR TITLE
chore: rename qody-bot references to repo-bot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Qodea/Qody-Bot
+* @Qodea/repo-bot

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Renovate Bot Config
 
 Central Renovate Config Repo
-Runs with Qody-Bot Github App
+Runs with repo-bot Github App


### PR DESCRIPTION
## Summary
- Renames `@Qodea/Qody-Bot` to `@Qodea/repo-bot` in CODEOWNERS
- Updates README to reflect the app rename from qody-bot to repo-bot

Part of renaming the qody-bot and sudo-qody GitHub Apps to repo-bot and sudo-bot to avoid confusion with the internal Qody project.

## Notes
- CODEOWNERS review is not enforced by rulesets, so the stale team reference won't block anything while this PR is open
- No workflows or branch protections reference the app by name

🤖 Generated with [Claude Code](https://claude.com/claude-code)